### PR TITLE
Modernize code to work with M1 Macs and recent Docker versions

### DIFF
--- a/diffprep
+++ b/diffprep
@@ -5,7 +5,7 @@ if [ $# -lt 1 ]; then
 fi
 
 docker-compose up -d
-./wait_for_port 9906
+./wait_for_container database
 ./upload "$1"
 
 # reexport

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   database:
+    platform: linux/x86_64
     image: mysql
     environment:
       - MYSQL_USER=mysql
@@ -13,6 +14,7 @@ services:
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
+    platform: linux/x86_64
     environment:
       - MYSQL_USER=mysql
       - MYSQL_PASSWORD=mysql
@@ -23,4 +25,3 @@ services:
       - "database:db"
     ports:
       - "9980:80"
-    

--- a/view
+++ b/view
@@ -10,4 +10,4 @@ docker-compose up -d
 ./upload "$1"
 ./wait_for_container phpmyadmin
 
-open "http://localhost:9980/db_structure.php?server=1&db=dump"
+open "http://localhost:9980/index.php?route=/database/sql&db=dump"

--- a/view
+++ b/view
@@ -6,8 +6,8 @@ fi
 
 docker-compose up -d
 
-./wait_for_port 9906
+./wait_for_container database
 ./upload "$1"
-./wait_for_port 9980
+./wait_for_container phpmyadmin
 
 open "http://localhost:9980/db_structure.php?server=1&db=dump"

--- a/wait_for_container
+++ b/wait_for_container
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo -n "waiting for container $1"
+# `docker compose ps --services` prints just the filtered service names; so if we get the name out, the service matches the filter, i.e. 'running'.
+while [ "`docker-compose ps --status running --services $1`" != "$1" ]; do
+  echo -n "."
+  sleep 1
+done
+echo

--- a/wait_for_port
+++ b/wait_for_port
@@ -1,7 +1,0 @@
-#!/bin/bash
-echo -n "waiting for port $1"
-while ! curl http://localhost:$1/ &> /dev/null; do
-  echo -n "."
-  sleep 1
-done
-echo


### PR DESCRIPTION
I ran into problems with Docker v20.x and M1 Macs. I'm by no means a Docker wizard, so this was trial and error for the most part; like `curl`ing into the mysql container not producing the expected output.